### PR TITLE
Run the unittest before building the RPM

### DIFF
--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -68,6 +68,12 @@ if [[ ! -f /usr/bin/pystache ]]; then
     pkg_install python2-pystache || pkg_install pystache
 fi
 
+echo "Ruuning unit tests"
+cd tests/aws
+pip3 install pyyaml==5.3
+python3 -m unittest test_scylla_configure.py
+cd -
+
 echo "Building in $PWD..."
 
 VERSION=$(./SCYLLA-VERSION-GEN)


### PR DESCRIPTION
Since in scylla-pkg this test phase was questioned
https://github.com/scylladb/scylla-pkg/pull/721#pullrequestreview-357376537

I think we are better off with having it here during the rpm build